### PR TITLE
Specify -Z axis for target ray intersection

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -143,7 +143,7 @@ This module adds a new event type to the definition of {{GlobalEventHandlers}}.
 onbeforexrselect {#onbeforexrselect}
 -------------
 
-An {{XRSessionEvent}} of type <dfn>beforexrselect</dfn> is dispatched on the DOM overlay element before generating a WebXR {{XRSession/selectstart}} input event if the input source's {{XRInputSource/targetRaySpace}} intersects the DOM overlay element at the time the input device's [=primary action=] is triggered.
+An {{XRSessionEvent}} of type <dfn>beforexrselect</dfn> is dispatched on the DOM overlay element before generating a WebXR {{XRSession/selectstart}} input event if the -Z axis of the input source's {{XRInputSource/targetRaySpace}} intersects the DOM overlay element at the time the input device's [=primary action=] is triggered.
 
 <pre class="idl">
 partial interface mixin GlobalEventHandlers {


### PR DESCRIPTION
Minor omission I noticed here and in webxr.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Manishearth/dom-overlays/pull/30.html" title="Last updated on May 1, 2020, 7:55 PM UTC (c1b2ff1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/dom-overlays/30/92a3949...Manishearth:c1b2ff1.html" title="Last updated on May 1, 2020, 7:55 PM UTC (c1b2ff1)">Diff</a>