### PR TITLE
fixed link errors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3,6 +3,7 @@ Shortname: webxr-dom-overlays
 Title: WebXR DOM Overlays Module
 Group: immersivewebwg
 Status: ED
+TR: https://www.w3.org/TR/webxr-dom-overlays-1/
 ED: https://immersive-web.github.io/dom-overlays/
 Repository: immersive-web/dom-overlays
 Level: 1
@@ -232,7 +233,7 @@ The UA MAY implement DOM Overlay as a special case of the [[FULLSCREEN]] API. In
 
 NOTE: The DOM Overlay API requires specifying the overlay element at session start, and does not provide a mechanism to change the active overlay element during the session. Applications would behave inconsistently across platforms if they could use the Fullscreen API to indirectly change the active overlay element.
 
-When DOM Overlay is implemented through the Fullscreen API, the [=root element=] [=stacking context=] does not paint to the immersive display. Only the stacking contexts for the elements in the [=top layer=], including the [=overlay element=], paint to the immersive display.
+When DOM Overlay is implemented through the Fullscreen API, the {{XRDOMOverlayInit/root}} element [=stacking context=] does not paint to the immersive display. Only the stacking contexts for the elements in the [=top layer=], including the [=overlay element=], paint to the immersive display.
 
 NOTE: By default, fullscreen mode uses an opaque black backdrop. The modified paint rules ensure that this backdrop does not need to be drawn, and that ancestors of the overlay element or sibling trees aren't visible through the transparent overlay element.
 
@@ -274,7 +275,7 @@ partial dictionary XRSessionInit {
 };
 </pre>
 
-If the DOM overlay feature is a required feature but the application did not supply a {{XRSessionInit/domOverlay}} member, the UA MUST treat this as an unresolved required feature and reject the {{XR/requestSession()}} promise with a {{NotSupportedError}}. If it was requested as an optional feature, the UA MUST ignore the feature request and not enable a DOM overlay.
+If the DOM overlay feature is a required feature but the application did not supply a {{XRSessionInit/domOverlay}} member, the UA MUST treat this as an unresolved required feature and reject the {{XRSystem/requestSession()}} promise with a {{NotSupportedError}}. If it was requested as an optional feature, the UA MUST ignore the feature request and not enable a DOM overlay.
 
 NOTE: The UA MAY emit local warnings such as developer console messages explaining why the DOM overlay was not enabled.
 


### PR DESCRIPTION
- For `[=root element=]', I believe this points an element with root configured, and replaced a link as `{{XRDOMOverlayInit/root}}`
- For `requestSession()`, now it is a method in `XRSystem` interface

Also, there are two links for `[=stacking context=], whose link points to [SVG2](https://svgwg.org/svg2-draft/render.html#TermStackingContext), but I suppose we should point [description of stacking context](https://www.w3.org/TR/CSS22/zindex.html#q0) in CSS2.2 (for [one in CSS pseudo-class section](https://immersive-web.github.io/dom-overlays/#css-pseudo-class)) or [new stacking layer](https://fullscreen.spec.whatwg.org/#new-stacking-layer) in fullscreen spec (for [one in fullscreen API integration](https://immersive-web.github.io/dom-overlays/#fullscreen-api-integration)). 
For these two, I've not touched in this PR.