### PR TITLE
Align with DOM suggested phrasing when firing an event

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -308,7 +308,7 @@ When an {{XRInputSource}} begins the platform-specific action corresponding as i
 <div class="algorithm" data-algorithm="on-before-input-start">
 
   1. If the input source's {{XRInputSource/targetRaySpace}} intersects the DOM overlay at the time the input device's [=primary action=] is triggered:
-    1. [=Queue a task=] to [=fire an event|fire=] an {{XRSessionEvent}} named [=beforexrselect=] on the [=topmost event target=] within the DOM overlay {{XRDOMOverlayInit/root}} being intersected by the {{XRInputSource/targetRaySpace}}, setting {{Event/target}} to that element. This events bubbles, is cancelable, and is composed.
+    1. [=Queue a task=] to [=fire an event=] named [=beforexrselect=] using {{XRSessionEvent}} on the [=topmost event target=] within the DOM overlay {{XRDOMOverlayInit/root}} being intersected by the {{XRInputSource/targetRaySpace}}, setting {{Event/target}} to that element. This events bubbles, is cancelable, and is composed.
     1. Check how XR input should be handled as follows:
         <dl class="switch">
           <dt>If the event was cancelled</dt>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/dom-overlays/pull/52.html" title="Last updated on Jun 3, 2022, 9:45 AM UTC (c256efa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/dom-overlays/52/e582142...c256efa.html" title="Last updated on Jun 3, 2022, 9:45 AM UTC (c256efa)">Diff</a>