### PR TITLE
Give :xr-overlay a definition type

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -176,7 +176,7 @@ document.getElementById('button-container').addEventListener(
 CSS pseudo-class {#css-pseudo-class}
 ----------------
 
-The <dfn export>:xr-overlay</dfn> [=pseudo-class=] MUST match the [=overlay element=] for the duration of an immersive session using a DOM Overlay.
+The <dfn selector export>:xr-overlay</dfn> [=pseudo-class=] MUST match the [=overlay element=] for the duration of an immersive session using a DOM Overlay.
 
 The [=overlay element=] is a [=backdrop root=].
 


### PR DESCRIPTION
Bikeshed doesn't infer CSS types for definition by default, so you need to specify when something is a selector.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tabatkins/dom-overlays/pull/56.html" title="Last updated on Sep 23, 2024, 4:39 PM UTC (c9b6a03)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/dom-overlays/56/233c356...tabatkins:c9b6a03.html" title="Last updated on Sep 23, 2024, 4:39 PM UTC (c9b6a03)">Diff</a>