### PR TITLE
fixed html syntax

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -435,4 +435,3 @@ The following individuals have contributed to the design of the WebXR DOM Overla
   * <a href="mailto:bajones@google.com">Brandon Jones</a> (Google)
   * <a href="mailto:nhw@amazon.com">Nell Waliczek</a> (Amazon [Microsoft until 2018])
 
-</section>


### PR DESCRIPTION
as title.

this seems remaining from 2022, so might just be garbase.